### PR TITLE
Provide `tag` and `register_tags` methods

### DIFF
--- a/lib/sinatra_doc/docs/configuration.rb
+++ b/lib/sinatra_doc/docs/configuration.rb
@@ -33,5 +33,10 @@ module SinatraDoc
       tags
       @tags << { name: name, description: description }
     end
+
+    def register_tags(tags_array)
+      raise ArgumentError, "Tags must be an array" unless tags_array.is_a?(Array)
+      tags_array.each{|tag| register_tag(tag) }
+    end
   end
 end

--- a/lib/sinatra_doc/docs/endpoint.rb
+++ b/lib/sinatra_doc/docs/endpoint.rb
@@ -30,6 +30,10 @@ module SinatraDoc
       @description
     end
 
+    def tag(value)
+      tags << value
+    end
+
     def tags(value = nil)
       if value
         raise ArgumentError, "Tags must be an array" unless value.is_a?(Array)


### PR DESCRIPTION
`tag` accepts a string, and adds a single tag of that string to the array of tags on an endpoint (by calling `tags << tag`)
`register_tags` accepts an array, and registers all the tags in the array (by calling `tags.each{|tag| register_tag tag }`)